### PR TITLE
Fix visibility issue with the doc update binary target

### DIFF
--- a/bazeldoc/internal/update_doc.bzl
+++ b/bazeldoc/internal/update_doc.bzl
@@ -32,5 +32,5 @@ def update_doc(doc_provs, doc_path = "doc"):
         name = "update",
         srcs = ["update.sh"],
         data = [doc_prov.out_basename for doc_prov in doc_provs],
-        visibility = ["//visibility:public"],
+        visibility = ["@//visibility:public"],
     )

--- a/bazeldoc/internal/update_doc.bzl
+++ b/bazeldoc/internal/update_doc.bzl
@@ -32,5 +32,7 @@ def update_doc(doc_provs, doc_path = "doc"):
         name = "update",
         srcs = ["update.sh"],
         data = [doc_prov.out_basename for doc_prov in doc_provs],
+        # The '@' in the following visibility is important. It makes the
+        # target visible relative to the repository where it is being used.
         visibility = ["@//visibility:public"],
     )


### PR DESCRIPTION
The target needs to be visible relative to the workspace where it is being used. This allows the client to reference it in any number of ways.