### PR TITLE
Add rules_bzlformat 0.2.0

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -34,3 +34,34 @@ jobs:
       run: |
         bazelisk build //... 
 
+  ubuntu_build:
+
+    runs-on: ubuntu-20.04
+
+    env:
+      CC: clang
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Write local.bazelrc File
+      shell: bash
+      run: |
+        cat >local.bazelrc <<EOF
+        common --config=ci
+        EOF
+
+    - name: Output the Bazel Info
+      shell: bash
+      run: |
+        bazelisk info
+
+    - name: Execute Tests
+      shell: bash
+      run: |
+        bazelisk test //... 
+
+    - name: Build Anything Not Tested
+      shell: bash
+      run: |
+        bazelisk build //... 

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -34,6 +34,11 @@ jobs:
       run: |
         bazelisk build //... 
 
+    - name: Ensure Bazel packages covered by bzlformat_pkg
+      shell: bash
+      run: |
+        bazelisk run //:bzlformat_missing_pkgs_test
+
   ubuntu_build:
 
     runs-on: ubuntu-20.04
@@ -65,3 +70,9 @@ jobs:
       shell: bash
       run: |
         bazelisk build //... 
+
+    - name: Ensure Bazel packages covered by bzlformat_pkg
+      shell: bash
+      run: |
+        bazelisk run //:bzlformat_missing_pkgs_test
+

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,14 +1,23 @@
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load(
+    "@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl",
+    "bzlformat_missing_pkgs",
+    "bzlformat_pkg",
+)
 load(
     "@cgrindel_rules_updatesrc//updatesrc:updatesrc.bzl",
     "updatesrc_update_all",
+)
+
+bzlformat_pkg(name = "bzlformat")
+
+bzlformat_missing_pkgs(
+    name = "bzlformat_missing_pkgs",
 )
 
 updatesrc_update_all(
     name = "update_all",
     targets_to_run = [
         "//doc:update",
+        ":bzlformat_missing_pkgs_fix",
     ],
 )
-
-bzlformat_pkg(name = "bzlformat")

--- a/bazeldoc/BUILD.bazel
+++ b/bazeldoc/BUILD.bazel
@@ -3,6 +3,8 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 package(default_visibility = ["//visibility:public"])
 
+bzlformat_pkg(name = "bzlformat")
+
 # NOTE: We cannot create a bzl_library for deps.bzl because it references @bazel_tools.
 # Issue: https://github.com/bazelbuild/bazel-skylib/issues/127
 exports_files(["deps.bzl"])
@@ -17,5 +19,3 @@ bzl_library(
         "//bazeldoc/internal:write_header",
     ],
 )
-
-bzlformat_pkg(name = "bzlformat")

--- a/bazeldoc/deps.bzl
+++ b/bazeldoc/deps.bzl
@@ -26,7 +26,7 @@ def bazeldoc_dependencies():
     maybe(
         http_archive,
         name = "cgrindel_rules_bzlformat",
-        sha256 = "b45b392613092b42c4ee94051be104b990e3c8651dea17410dfd63b98957cd57",
-        strip_prefix = "rules_bzlformat-0.1.0",
-        urls = ["https://github.com/cgrindel/rules_bzlformat/archive/v0.1.0.tar.gz"],
+        sha256 = "df22d867e661de66a255a994caf814ff66426a43873194575bcaaaf9b9ad89ed",
+        strip_prefix = "rules_bzlformat-0.2.0",
+        urls = ["https://github.com/cgrindel/rules_bzlformat/archive/v0.2.0.tar.gz"],
     )

--- a/bazeldoc/internal/BUILD.bazel
+++ b/bazeldoc/internal/BUILD.bazel
@@ -3,6 +3,8 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 package(default_visibility = ["//bazeldoc:__subpackages__"])
 
+bzlformat_pkg(name = "bzlformat")
+
 bzl_library(
     name = "diff_test_for_provs",
     srcs = ["diff_test_for_provs.bzl"],
@@ -72,5 +74,3 @@ bzl_library(
         ":write_doc",
     ],
 )
-
-bzlformat_pkg(name = "bzlformat")

--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -7,6 +7,8 @@ load(
     doc_providers = "providers",
 )
 
+bzlformat_pkg(name = "bzlformat")
+
 # Lovingly inspired by
 # https://github.com/bazelbuild/rules_swift/blob/021c11b1d578ffba547140eb24854cdfe74c794f/doc/BUILD.bazel#L3
 
@@ -90,5 +92,3 @@ write_header(
 ]
 
 doc_for_provs(doc_provs = _ALL_DOC_PROVIDERS)
-
-bzlformat_pkg(name = "bzlformat")


### PR DESCRIPTION
Closes #10.

- Added `rules_bzlformat` including `bzlformat_missing_pkgs`.
- Added Ubuntu CI runner.